### PR TITLE
added support for `formam:"-"` to skip a field from binding

### DIFF
--- a/formam.go
+++ b/formam.go
@@ -465,17 +465,15 @@ func (dec *Decoder) decode() error {
 			if dec.opts.IgnoreUnknownKeys {
 				return nil
 			}
-			/*
-				if dec.isKey {
-					tmp := dec.curr
-					dec.field = dec.value
-					if err := dec.begin(); err != nil {
-						return err
-					}
-					dec.curr = tmp
+			num := dec.curr.NumField()
+			for i := 0; i < num; i++ {
+				field := dec.curr.Type().Field(i)
+				tag := field.Tag.Get(dec.opts.TagName)
+				if tag == "-" {
+					// skip this field
 					return nil
 				}
-			*/
+			}
 			return newError(fmt.Errorf("not supported type for field \"%v\" in path \"%v\". Maybe you should to include it the UnmarshalText interface or register it using custom type?", dec.field, dec.path))
 		}
 	default:
@@ -493,6 +491,11 @@ func (dec *Decoder) findStructField() error {
 	num := dec.curr.NumField()
 	for i := 0; i < num; i++ {
 		field := dec.curr.Type().Field(i)
+		tag := field.Tag.Get(dec.opts.TagName)
+		if tag == "-" {
+			// skip this field
+			return nil
+		}
 		if field.Name == dec.field {
 			// check if the field's name is equal
 			dec.curr = dec.curr.Field(i)

--- a/formam_test.go
+++ b/formam_test.go
@@ -749,3 +749,22 @@ func TestEmptyString(t *testing.T) {
 		t.Errorf("Expected empty string got %s", s.Name)
 	}
 }
+
+func TestIgnoredStructTag(t *testing.T) {
+	s := struct {
+		Name string `formam:"-"`
+	}{
+		Name: "Homer",
+	}
+	vals := url.Values{
+		"Name": []string{"Marge"},
+	}
+	dec := NewDecoder(&DecoderOptions{})
+	err := dec.Decode(vals, &s)
+	if err != nil {
+		t.Error(err)
+	}
+	if s.Name != "Homer" {
+		t.Errorf("Expected Homer got %s", s.Name)
+	}
+}


### PR DESCRIPTION
On some structs you don't want to bind a form field, even it is in the request. The standard way of doing this is to use a struct tag with `-` as the value, see JSON and XML in the standard library. This PR adds support for that in formam.

```go
struct {
  Name string `formam:"-"`
}
```