### PR TITLE
Also ignore parameters that end with a . or [

### DIFF
--- a/formam.go
+++ b/formam.go
@@ -476,6 +476,10 @@ func (dec *Decoder) decode() error {
 			return newError(fmt.Errorf("not supported type for field \"%v\" in path \"%v\". Maybe you should to include it the UnmarshalText interface or register it using custom type?", dec.field, dec.path))
 		}
 	default:
+		if dec.opts.IgnoreUnknownKeys {
+			return nil
+		}
+
 		return newError(fmt.Errorf("not supported type for field \"%v\" in path \"%v\"", dec.field, dec.path))
 	}
 

--- a/formam_test.go
+++ b/formam_test.go
@@ -468,7 +468,7 @@ func TestDecodeInStruct(t *testing.T) {
 	} else if len(*m.PointerToMap) == 0 {
 		t.Error("PointerToMap is not nil but is empty")
 	} else {
-		for k, _ := range *m.PointerToMap {
+		for k := range *m.PointerToMap {
 			if (*m.PointerToMap)[k] == "" {
 				t.Error("PointerToMap[" + k + "] is empty")
 			}
@@ -713,11 +713,15 @@ func TestDecodeInSlice(t *testing.T) {
 
 func TestIgnoreUnknownKeys(t *testing.T) {
 	s := struct {
-		Name string
+		Name  string `formam:"Name"`
+		Map   map[string]string
+		Slice []string
 	}{}
 	vals := url.Values{
-		"Name": []string{"Homer"},
-		"City": []string{"Springfield"},
+		"Name":      []string{"Homer"},
+		"City":      []string{"Springfield"},
+		"Children.": []string{"Bart", "Lisa"},
+		"Job[":      []string{"Safety inspector"},
 	}
 	dec := NewDecoder(&DecoderOptions{
 		IgnoreUnknownKeys: true,


### PR DESCRIPTION
I'm calling `NewDecoder()` with `IgnoreUnknownKeys` set to `true`. This works
brilliant, except when people send up form parameter keys that end with a `.`
and `[`, in which case it would still trigger errors.

This PR adds an extra check to also ignore those form paramters.