### PR TITLE
Ignore unknown keys in brackets

### DIFF
--- a/formam.go
+++ b/formam.go
@@ -147,6 +147,9 @@ func (dec Decoder) init() error {
 		dec.values = v
 		dec.curr = dec.main
 		if err := dec.analyzePath(); err != nil {
+			if dec.opts.IgnoreUnknownKeys {
+				continue
+			}
 			return err
 		}
 	}

--- a/formam.go
+++ b/formam.go
@@ -147,7 +147,7 @@ func (dec Decoder) init() error {
 		dec.values = v
 		dec.curr = dec.main
 		if err := dec.analyzePath(); err != nil {
-			if dec.opts.IgnoreUnknownKeys {
+			if dec.curr.Kind() == reflect.Struct && dec.opts.IgnoreUnknownKeys {
 				continue
 			}
 			return err

--- a/formam_test.go
+++ b/formam_test.go
@@ -735,6 +735,67 @@ func TestIgnoreUnknownKeys(t *testing.T) {
 	}
 }
 
+func TestIgnoreBracketedKeys(t *testing.T) {
+	t.Run("errStruct", func(t *testing.T) {
+		s := struct {
+			Name string `formam:"Name"`
+		}{}
+		vals := url.Values{
+			"Name":      []string{"Homer"},
+			"[Wife]":    []string{"Marge"},
+			"His[Wife]": []string{"Marge"},
+		}
+		dec := NewDecoder(&DecoderOptions{})
+		err := dec.Decode(vals, &s)
+		if err == nil {
+			t.Error("error is not nil")
+		}
+	})
+
+	t.Run("ignoreStruct", func(t *testing.T) {
+		s := struct {
+			Name string `formam:"Name"`
+		}{}
+		vals := url.Values{
+			"Name":      []string{"Homer"},
+			"[Wife]":    []string{"Marge"},
+			"His[Wife]": []string{"Marge"},
+		}
+		dec := NewDecoder(&DecoderOptions{
+			IgnoreUnknownKeys: true,
+		})
+		err := dec.Decode(vals, &s)
+		if err != nil {
+			t.Error(err)
+		}
+		if s.Name != "Homer" {
+			t.Errorf("Expected Homer got %s", s.Name)
+		}
+	})
+
+	t.Run("ignoreSlice", func(t *testing.T) {
+		s := []string{}
+		vals := url.Values{
+			"Name":      []string{"Homer"},
+			"[Wife]":    []string{"Marge"},
+			"His[Wife]": []string{"Marge"},
+		}
+		dec := NewDecoder(&DecoderOptions{
+			IgnoreUnknownKeys: true,
+		})
+		err := dec.Decode(vals, &s)
+		if err != nil {
+			t.Error(err)
+		}
+		if len(s) != 1 {
+			t.Errorf("Expected len() 1 got %d", len(s))
+		}
+		if s[0] != "Homer" {
+			t.Errorf("Expected Homer got %s", s[0])
+		}
+	})
+}
+
 func TestEmptyString(t *testing.T) {
 	s := struct {
 		Name string

--- a/formam_test.go
+++ b/formam_test.go
@@ -735,65 +735,63 @@ func TestIgnoreUnknownKeys(t *testing.T) {
 	}
 }
 
-func TestIgnoreBracketedKeys(t *testing.T) {
-	t.Run("errStruct", func(t *testing.T) {
-		s := struct {
-			Name string `formam:"Name"`
-		}{}
-		vals := url.Values{
-			"Name":      []string{"Homer"},
-			"[Wife]":    []string{"Marge"},
-			"His[Wife]": []string{"Marge"},
-		}
-		dec := NewDecoder(&DecoderOptions{})
-		err := dec.Decode(vals, &s)
-		if err == nil {
-			t.Error("error is not nil")
-		}
-	})
+func TestIgnoreBracketedKeysError(t *testing.T) {
+	s := struct {
+		Name string `formam:"Name"`
+	}{}
+	vals := url.Values{
+		"Name":      []string{"Homer"},
+		"[Wife]":    []string{"Marge"},
+		"His[Wife]": []string{"Marge"},
+	}
+	dec := NewDecoder(&DecoderOptions{})
+	err := dec.Decode(vals, &s)
+	if err == nil {
+		t.Error("error is not nil")
+	}
+}
 
-	t.Run("ignoreStruct", func(t *testing.T) {
-		s := struct {
-			Name string `formam:"Name"`
-		}{}
-		vals := url.Values{
-			"Name":      []string{"Homer"},
-			"[Wife]":    []string{"Marge"},
-			"His[Wife]": []string{"Marge"},
-		}
-		dec := NewDecoder(&DecoderOptions{
-			IgnoreUnknownKeys: true,
-		})
-		err := dec.Decode(vals, &s)
-		if err != nil {
-			t.Error(err)
-		}
-		if s.Name != "Homer" {
-			t.Errorf("Expected Homer got %s", s.Name)
-		}
+func TestIgnoreBracketedKeysIgnoreStruct(t *testing.T) {
+	s := struct {
+		Name string `formam:"Name"`
+	}{}
+	vals := url.Values{
+		"Name":      []string{"Homer"},
+		"[Wife]":    []string{"Marge"},
+		"His[Wife]": []string{"Marge"},
+	}
+	dec := NewDecoder(&DecoderOptions{
+		IgnoreUnknownKeys: true,
 	})
+	err := dec.Decode(vals, &s)
+	if err != nil {
+		t.Error(err)
+	}
+	if s.Name != "Homer" {
+		t.Errorf("Expected Homer got %s", s.Name)
+	}
+}
 
-	t.Run("ignoreSlice", func(t *testing.T) {
-		s := []string{}
-		vals := url.Values{
-			"Name":      []string{"Homer"},
-			"[Wife]":    []string{"Marge"},
-			"His[Wife]": []string{"Marge"},
-		}
-		dec := NewDecoder(&DecoderOptions{
-			IgnoreUnknownKeys: true,
-		})
-		err := dec.Decode(vals, &s)
-		if err != nil {
-			t.Error(err)
-		}
-		if len(s) != 1 {
-			t.Errorf("Expected len() 1 got %d", len(s))
-		}
-		if s[0] != "Homer" {
-			t.Errorf("Expected Homer got %s", s[0])
-		}
+func TestIgnoreBracketedKeysIgnoreSlice(t *testing.T) {
+	s := []string{}
+	vals := url.Values{
+		"Name":      []string{"Homer"},
+		"[Wife]":    []string{"Marge"},
+		"His[Wife]": []string{"Marge"},
+	}
+	dec := NewDecoder(&DecoderOptions{
+		IgnoreUnknownKeys: true,
 	})
+	err := dec.Decode(vals, &s)
+	if err != nil {
+		t.Error(err)
+	}
+	if len(s) != 1 {
+		t.Errorf("Expected len() 1 got %d", len(s))
+	}
+	if s[0] != "Homer" {
+		t.Errorf("Expected Homer got %s", s[0])
+	}
 }
 
 func TestEmptyString(t *testing.T) {

--- a/formam_test.go
+++ b/formam_test.go
@@ -691,8 +691,6 @@ func TestDecodeInStruct(t *testing.T) {
 	if m.TimeDefault.IsZero() {
 		t.Error("The value of TimeDefault is not correct")
 	}
-
-	fmt.Println("RESULT: ", m)
 }
 
 type TestSlice []string
@@ -708,7 +706,6 @@ func TestDecodeInSlice(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	fmt.Println("RESULT: ", t2)
 }
 
 func TestIgnoreUnknownKeys(t *testing.T) {
@@ -751,6 +748,22 @@ func TestIgnoreBracketedKeysError(t *testing.T) {
 	}
 }
 
+func TestIgnoreBracketedKeysIgnoreError(t *testing.T) {
+	s := []string{}
+	vals := url.Values{
+		"Name":      []string{"Homer"},
+		"[Wife]":    []string{"Marge"},
+		"His[Wife]": []string{"Marge"},
+	}
+	dec := NewDecoder(&DecoderOptions{
+		IgnoreUnknownKeys: true,
+	})
+	err := dec.Decode(vals, &s)
+	if err == nil {
+		t.Error("error is not nil")
+	}
+}
+
 func TestIgnoreBracketedKeysIgnoreStruct(t *testing.T) {
 	s := struct {
 		Name string `formam:"Name"`
@@ -769,28 +782,6 @@ func TestIgnoreBracketedKeysIgnoreStruct(t *testing.T) {
 	}
 	if s.Name != "Homer" {
 		t.Errorf("Expected Homer got %s", s.Name)
-	}
-}
-
-func TestIgnoreBracketedKeysIgnoreSlice(t *testing.T) {
-	s := []string{}
-	vals := url.Values{
-		"Name":      []string{"Homer"},
-		"[Wife]":    []string{"Marge"},
-		"His[Wife]": []string{"Marge"},
-	}
-	dec := NewDecoder(&DecoderOptions{
-		IgnoreUnknownKeys: true,
-	})
-	err := dec.Decode(vals, &s)
-	if err != nil {
-		t.Error(err)
-	}
-	if len(s) != 1 {
-		t.Errorf("Expected len() 1 got %d", len(s))
-	}
-	if s[0] != "Homer" {
-		t.Errorf("Expected Homer got %s", s[0])
 	}
 }
 


### PR DESCRIPTION
For example:

    [Foo]: bar
    Foo[bar]: foobar

Previously this would error out with:

	--- FAIL: TestIgnoreBracketedKeys (0.00s)
		--- FAIL: TestIgnoreBracketedKeys/struct (0.00s)
			formam_test.go:753: formam: the field "" in path "His[Wife]" has a index for array but it is a struct
		--- FAIL: TestIgnoreBracketedKeys/slice (0.00s)
			formam_test.go:772: formam: the index of slice is not a number in the field "" of path "His[Wife]"

I don't think this is the correct behaviour if `IgnoreUnknownKeys` is given.