### PR TITLE
Add go.mod file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/monoculum/formam
+
+go 1.12


### PR DESCRIPTION
This is useful even when the project doesn't have any dependencies, as
it will allow the "go" tool, various helper tools, and IDEs recognize
which import path this is when using it outside of GOPATH