### PR TITLE
Ignore struct tag options

### DIFF
--- a/formam.go
+++ b/formam.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"reflect"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -526,7 +527,7 @@ func (dec *Decoder) findStructField() error {
 			// (a field with same name in the current struct should have preference over anonymous struct)
 			anon = dec.curr
 			dec.curr = tmp
-		} else if dec.field == field.Tag.Get(dec.opts.TagName) {
+		} else if dec.field == getTagName(field.Tag, dec.opts.TagName) {
 			// is not found yet, then retry by its tag name "formam"
 			dec.curr = dec.curr.Field(i)
 			return nil
@@ -619,4 +620,12 @@ func (dec *Decoder) isUnmarshalText(v reflect.Value) (bool, error) {
 	}
 	// return result
 	return true, m.UnmarshalText([]byte(dec.values[0]))
+}
+
+func getTagName(t reflect.StructTag, tagName string) string {
+	tag := t.Get(tagName)
+	if p := strings.Index(tag, ","); p != -1 {
+		return tag[:p]
+	}
+	return tag
 }

--- a/formam_test.go
+++ b/formam_test.go
@@ -147,7 +147,8 @@ type TestStruct struct {
 	UnmarshalTextUUID   UUID
 
 	// tag
-	Tag string `formam:"tag"`
+	Tag    string `formam:"tag"`
+	TagOpt string `formam:"tagopt,x"`
 
 	// time
 	Time time.Time
@@ -253,7 +254,8 @@ var vals = url.Values{
 	"UnmarshalTextUUID":   []string{"11e5bf2d3e403a8c86740023dffe5350"},
 
 	// tag
-	"tag": []string{"string placed by tag"},
+	"tag":    []string{"string placed by tag"},
+	"tagopt": []string{"string placed by tagopt"},
 
 	// time
 	"Time": []string{"2016-06-12"},


### PR DESCRIPTION
I have a simple struct:

	type Test struct
		Name     string `json:"name"`
		Website  string `json:"website,omitempty"`
	}

Since the names for `json` and the HTTP form are the same I thought I'd
be clever and use `TagName: "json"` with formam. Unfortunately that
doesn't work as the options (everything after the comma, ",omitempty")
aren't ignored.

This patch fixes that.