### PR TITLE
Improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 formam
 ======
 
-A package for decode form's values into struct in Go. 
+A Go package to decode HTTP form and query parameters.
 The only requirement is [Go 1.2](http://golang.org/doc/go1.2) or later.
 
 [![Build Status](https://travis-ci.org/monoculum/formam.png?branch=master)](https://travis-ci.org/monoculum/formam)
@@ -10,132 +10,53 @@ The only requirement is [Go 1.2](http://golang.org/doc/go1.2) or later.
 Features
 --------
 
-* Nesting ad infinitum in `maps`, `structs` and `slices`.
-* `UnmarshalText` in values and keys of maps.
-* the `map`'s key supported are: `string`, `int` and variants, `uint` and variants, `uintptr`, `float32`, `float64`, `bool`, `struct`, `custom types` to one of the above types registered by function or `UnmarshalText` method, a `pointer` to one of the above types
-* A field with `interface{}` that has a `map`, `struct` or `slice` as value is perfectly possible access to them! (see example below)
-* decode `time.Time` with format "2006-01-02" by its UnmarshalText method.
-* decode `url.URL`
-* The `slice` and `array` is possible to access without to indicate a index (If it is the last field, of course)`
-* You can to register a `func` for a `custom type` for all fields that include it or one in particular! (see example below)
+* Infinite nesting for `maps`, `structs` and `slices`.
+* Support `UnmarshalText()` interface in values and keys of maps.
+* Supported `map` keys are `string`, `int` and variants, `uint` and variants, `uintptr`, `float32`, `float64`, `bool`, `struct`, `custom types` to one of the above types registered by function or `UnmarshalText` method, a `pointer` to one of the above types
+* A field with `interface{}` that has a `map`, `struct` or `slice` as value is accessible.
+* Decode `time.Time` with format `2006-01-02` by its `UnmarshalText()` method.
+* Decode `url.URL`.
+* Append to `slice` and `array` types without explicitly indicating an index.
+* Register a function for a custom type.
 
 Performance
 -----------
 
 You can see the performance in [formam-benchmark](https://github.com/monoculum/formam-benchmark) compared with [ajg/form](https://github.com/ajg/form), [gorilla/schema](https://github.com/gorilla/schema), [go-playground/form](https://github.com/go-playground/form) and [built-in/json](http://golang.org/pkg/encoding/json/).
 
-Types
------
+Basic usage example
+-------------------
 
-The supported field types in the destination struct are:
+### In form HTML
 
-* `string`
-* `bool`
-* `int`, `int8`, `int16`, `int32`, `int64`
-* `uint`, `uint8`, `uint16`, `uint32`, `uint64`
-* `float32`, `float64`
-* `slice`, `array`
-* `struct` and `struct anonymous`
-* `map`
-* `interface{}`
-* `time.Time`
-* `url.URL`
-* `custom types` to one of the above types
-* a `pointer` to one of the above types
-
-**NOTE**: the nesting in `maps`, `structs` and `slices` can be ad infinitum.
-
-Custom Marshaling
------------------
-
-Is possible unmarshaling data and the key of a map by the `encoding.TextUnmarshaler` interface.
-
-Custom Type
------------
-
-Is possible to register a function for a custom type for all fields that include it or one in particular. Types registered has preference over UnmarshalText method.
-For example:
-
-##### All fields
-
-```go
-decoder.RegisterCustomType(func(vals []string) (interface{}, error) {
-        return time.Parse("2006-01-02", vals[0])
-}, []interface{}{time.Time{}}, nil)
-```
-
-##### Specific fields
-
-```go
-package main
-
-type Times struct {
-    Timestamp   time.Time
-    Time        time.Time
-    TimeDefault time.Time
-}
-
-func main() {
-    var t Timestamp
-    
-    dec := NewDecoder(nil)
-    // for Timestamp field
-    dec.RegisterCustomType(func(vals []string) (interface{}, error) {
-            return time.Parse("2006-01-02T15:04:05Z07:00", vals[0])
-    }, []interface{}{time.Time{}}, []interface{}{&t.Timestamp{}}) 
-    // for Time field
-    dec.RegisterCustomType(func(vals []string) (interface{}, error) {
-                return time.Parse("Mon, 02 Jan 2006 15:04:05 MST", vals[0])
-    }, []interface{}{time.Time{}}, []interface{}{&t.Time{}}) 
-    // for field that not be Time or Timestamp, i.e, in this example, TimeDefault.
-    dec.RegisterCustomType(func(vals []string) (interface{}, error) {
-                return time.Parse("2006-01-02", vals[0])
-    }, []interface{}{time.Time{}}, nil)
-    
-    dec.Decode(url.Values{}, &t)
-}
-```
-
-Notes
------
-
-The version 2 is compatible with old syntax for to access to maps, i.e., by point.
-If you is using this package for first time in your project, please, use the brackets for to access to maps.
-
-
-Usage
------
-
-### In form html
-
-- Use symbol `.` for access a field of a struct. (i.e, `struct.field1`)
-- Use `[<index>]` for access to index of a slice/array. (i.e, `struct.array[0]`). If the array/slice is the last field of the path, it is not necessary to indicate the index
-- Use `[<key>]` for access to key of a map. (i.e, `struct.map[es-ES]`).
+- Use `.` to access a struct field (e.g. `struct.field1`).
+- Use `[<index>]` to access tje specific slice/array index (e.g. `struct.array[0]`). It's not necessary to add an index to append data.
+- Use `[<key>]` to access map keys (e.g.. `struct.map[es-ES]`).
 
 ```html
 <form method="POST">
-  <input type="text" name="Name" value="Sony"/>
-  <input type="text" name="Location.Country" value="Japan"/>
-  <input type="text" name="Location.City" value="Tokyo"/>
-  <input type="text" name="Products[0].Name" value="Playstation 4"/>
-  <input type="text" name="Products[0].Type" value="Video games"/>
-  <input type="text" name="Products[1].Name" value="TV Bravia 32"/>
-  <input type="text" name="Products[1].Type" value="TVs"/>
-  <input type="text" name="Founders[0]" value="Masaru Ibuka"/>
-  <input type="text" name="Founders[0]" value="Akio Morita"/>
-  <input type="text" name="Employees" value="90000"/>
-  <input type="text" name="public" value="true"/>
-  <input type="url" name="website" value="http://www.sony.net"/>
-  <input type="date" name="foundation" value="1946-05-07"/>
-  <input type="text" name="Interface.ID" value="12"/>
-  <input type="text" name="Interface.Name" value="Go Programming Language"/>
-  <input type="submit"/>
+  <input type="text" name="Name" value="Sony">
+  <input type="text" name="Location.Country" value="Japan">
+  <input type="text" name="Location.City" value="Tokyo">
+  <input type="text" name="Products[0].Name" value="Playstation 4">
+  <input type="text" name="Products[0].Type" value="Video games">
+  <input type="text" name="Products[1].Name" value="TV Bravia 32">
+  <input type="text" name="Products[1].Type" value="TVs">
+  <input type="text" name="Founders[0]" value="Masaru Ibuka">
+  <input type="text" name="Founders[0]" value="Akio Morita">
+  <input type="text" name="Employees" value="90000">
+  <input type="text" name="public" value="true">
+  <input type="url" name="website" value="http://www.sony.net">
+  <input type="date" name="foundation" value="1946-05-07">
+  <input type="text" name="Interface.ID" value="12">
+  <input type="text" name="Interface.Name" value="Go Programming Language">
+  <input type="submit">
 </form>
 ```
 
-### In golang
+### In Go
 
-You can use the tag `formam` if the name of a input of form starts lowercase.
+You can use the `formam` struct tag to ensure the form values are unmarshalled in the currect struct fields.
 
 ```go
 type InterfaceStruct struct {
@@ -158,19 +79,97 @@ type Company struct {
   }
   Founders   []string
   Employees  int64
-  
+
   Interface interface{}
 }
 
 func MyHandler(w http.ResponseWriter, r *http.Request) error {
-  m := Company{
-      Interface: &InterfaceStruct{}, // its is possible to access to the fields although it's an interface field!
-  }
   r.ParseForm()
-  dec := formam.NewDecoder(&formam.DecoderOptions{TagName: "formam"})
-  if err := dec.Decode(r.Form, &m); err != nil {
-  		return err
+
+  m := Company{
+      // it's is possible to access to the fields although it's an interface field!
+      Interface: &InterfaceStruct{},
   }
-  return nil
+  dec := formam.NewDecoder(&formam.DecoderOptions{TagName: "formam"})
+  return dec.Decode(r.Form, &m)
 }
 ```
+
+Types
+-----
+
+Supported types in the destination struct are:
+
+* `string`
+* `bool`
+* `int`, `int8`, `int16`, `int32`, `int64`
+* `uint`, `uint8`, `uint16`, `uint32`, `uint64`
+* `float32`, `float64`
+* `slice`, `array`
+* `struct` and `struct anonymous`
+* `map`
+* `interface{}`
+* `time.Time`
+* `url.URL`
+* `custom types` to one of the above types
+* a `pointer` to one of the above types
+
+Custom Marshaling
+-----------------
+
+You can umarshal data and map keys by implementing the `encoding.TextUnmarshaler` interface.
+
+Custom Type
+-----------
+
+You can register a function for a custom type using the `RegisterCustomType()` method. This will work for any number of given fields or all fields with the given type.
+
+Registered type have preference over the UnmarshalText method unless the `PrefUnmarshalText` option is used.
+
+### All fields
+
+```go
+decoder.RegisterCustomType(func(vals []string) (interface{}, error) {
+        return time.Parse("2006-01-02", vals[0])
+}, []interface{}{time.Time{}}, nil)
+```
+
+### Specific fields
+
+```go
+package main
+
+type Times struct {
+    Timestamp   time.Time
+    Time        time.Time
+    TimeDefault time.Time
+}
+
+func main() {
+    var t Timestamp
+
+    dec := NewDecoder(nil)
+
+    // for Timestamp field
+    dec.RegisterCustomType(func(vals []string) (interface{}, error) {
+            return time.Parse("2006-01-02T15:04:05Z07:00", vals[0])
+    }, []interface{}{time.Time{}}, []interface{}{&t.Timestamp{}}) 
+
+    // for Time field
+    dec.RegisterCustomType(func(vals []string) (interface{}, error) {
+                return time.Parse("Mon, 02 Jan 2006 15:04:05 MST", vals[0])
+    }, []interface{}{time.Time{}}, []interface{}{&t.Time{}}) 
+
+    // for field that not be Time or Timestamp, e.g. in this example, TimeDefault.
+    dec.RegisterCustomType(func(vals []string) (interface{}, error) {
+                return time.Parse("2006-01-02", vals[0])
+    }, []interface{}{time.Time{}}, nil)
+
+    dec.Decode(url.Values{}, &t)
+}
+```
+
+Notes
+-----
+
+Version 2 is compatible with old syntax to access to maps (`map.key`), but brackets are the preferred way to access a map (`map[key])`.

--- a/errors.go
+++ b/errors.go
@@ -2,6 +2,7 @@ package formam
 
 import (
 	"encoding/json"
+	"fmt"
 )
 
 type Error struct {
@@ -21,4 +22,6 @@ func (s *Error) Cause() error {
 	return s.err
 }
 
-func newError(err error) *Error { return &Error{err} }
+func newError(format string, a ...interface{}) error {
+	return &Error{fmt.Errorf(format, a...)}
+}

--- a/formam_test.go
+++ b/formam_test.go
@@ -1,4 +1,4 @@
-package formam
+package formam_test
 
 import (
 	"encoding/hex"
@@ -7,6 +7,8 @@ import (
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/monoculum/formam"
 )
 
 type Text string
@@ -280,7 +282,7 @@ func TestDecodeInStruct(t *testing.T) {
 	var m TestStruct
 	m.InterfaceStruct = &InterfaceStruct{}
 
-	dec := NewDecoder(nil).RegisterCustomType(func(vals []string) (interface{}, error) {
+	dec := formam.NewDecoder(nil).RegisterCustomType(func(vals []string) (interface{}, error) {
 		return FieldString("value changed by custom type"), nil
 	}, []interface{}{FieldString("")}, nil)
 
@@ -704,7 +706,7 @@ var sliceValues = url.Values{
 
 func TestDecodeInSlice(t *testing.T) {
 	var t2 TestSlice
-	err := Decode(sliceValues, &t2)
+	err := formam.Decode(sliceValues, &t2)
 	if err != nil {
 		t.Error(err)
 	}
@@ -722,7 +724,7 @@ func TestIgnoreUnknownKeys(t *testing.T) {
 		"Children.": []string{"Bart", "Lisa"},
 		"Job[":      []string{"Safety inspector"},
 	}
-	dec := NewDecoder(&DecoderOptions{
+	dec := formam.NewDecoder(&formam.DecoderOptions{
 		IgnoreUnknownKeys: true,
 	})
 	err := dec.Decode(vals, &s)
@@ -743,7 +745,7 @@ func TestIgnoreBracketedKeysError(t *testing.T) {
 		"[Wife]":    []string{"Marge"},
 		"His[Wife]": []string{"Marge"},
 	}
-	dec := NewDecoder(&DecoderOptions{})
+	dec := formam.NewDecoder(&formam.DecoderOptions{})
 	err := dec.Decode(vals, &s)
 	if err == nil {
 		t.Error("error is not nil")
@@ -757,7 +759,7 @@ func TestIgnoreBracketedKeysIgnoreError(t *testing.T) {
 		"[Wife]":    []string{"Marge"},
 		"His[Wife]": []string{"Marge"},
 	}
-	dec := NewDecoder(&DecoderOptions{
+	dec := formam.NewDecoder(&formam.DecoderOptions{
 		IgnoreUnknownKeys: true,
 	})
 	err := dec.Decode(vals, &s)
@@ -775,7 +777,7 @@ func TestIgnoreBracketedKeysIgnoreStruct(t *testing.T) {
 		"[Wife]":    []string{"Marge"},
 		"His[Wife]": []string{"Marge"},
 	}
-	dec := NewDecoder(&DecoderOptions{
+	dec := formam.NewDecoder(&formam.DecoderOptions{
 		IgnoreUnknownKeys: true,
 	})
 	err := dec.Decode(vals, &s)
@@ -796,7 +798,7 @@ func TestEmptyString(t *testing.T) {
 	vals := url.Values{
 		"Name": []string{""},
 	}
-	dec := NewDecoder(&DecoderOptions{})
+	dec := formam.NewDecoder(&formam.DecoderOptions{})
 	err := dec.Decode(vals, &s)
 	if err != nil {
 		t.Error(err)
@@ -822,7 +824,7 @@ func TestIgnoredStructTag(t *testing.T) {
 		"Phone":    []string{"555-333-222"},
 	}
 
-	dec := NewDecoder(&DecoderOptions{})
+	dec := formam.NewDecoder(&formam.DecoderOptions{})
 	err := dec.Decode(vals, &s)
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
This improves various parts of the godoc and README. Some docs could be
improved a bit more, but this should fix most of the grammar oddities.

I also improved the verbiage of errors, as some were a bit awkwardly
worded as well. I also changed some of the formatting specifiers from
`\"%v\"` to `%q`, as that looks a bit neater. Also use `fmt.Errorf()`
inside `newError()`, as every invocation of `newError()` was using it.
It also adds the checked error where applicable, which is more detailed
than "not valid".

I used my own judgement in changing some stuff around (e.g. putting the
usage example higher in the README). Feel free to point out if you don't
like some part and I can just change it back.

I unexported some types that serve no purpose for users of formam as far
as I can see to clean up the godoc a bit; I changed the tests to run
from another package (formam_test) to make sure it still works well from
another package (sometimes exporting is needed in decoding for
visibility, e.g. in json).

Fixes #1