### PR TITLE
Allow "param[]"

### DIFF
--- a/formam.go
+++ b/formam.go
@@ -212,7 +212,12 @@ func (dec *Decoder) analyzePath() (err error) {
 				// and put as false inBracket and pass the value of bracket to dec.key
 				inBracket = false
 				bracketClosed = true
-				dec.bracket = dec.path[lastPos:endPos]
+				if endPos == 0 { // foo[] without number.
+					dec.bracket = dec.path[lastPos:i]
+				} else {
+					dec.bracket = dec.path[lastPos:endPos]
+				}
+
 				lastPos = i + 1
 				if err = dec.traverse(); err != nil {
 					return

--- a/formam_test.go
+++ b/formam_test.go
@@ -842,3 +842,31 @@ func TestIgnoredStructTag(t *testing.T) {
 		t.Errorf("Expected new phone number '555-333-222' but got %s", s.Phone)
 	}
 }
+
+// Test for #7
+func TestPanic(t *testing.T) {
+	s := struct {
+		Foo []string `formam:"foo"`
+	}{}
+
+	vals := url.Values{
+		"foo[]": []string{"5", "6"},
+	}
+
+	dec := formam.NewDecoder(&formam.DecoderOptions{})
+	err := dec.Decode(vals, &s)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(s.Foo) != 2 {
+		t.Fatalf("len(s.Foo) is %d", len(s.Foo))
+	}
+	if s.Foo[0] != "5" {
+		t.Errorf("s.Foo[0] is %#v", s.Foo[0])
+	}
+	if s.Foo[1] != "6" {
+		t.Errorf("s.Foo[1] is %#v", s.Foo[1])
+	}
+
+}


### PR DESCRIPTION
Allow `<input name="param[]">` in addition to just
`<input name="param">`.

This is the least surprising behaviour, as many framework/libraries in
many different languages use the `param[]` syntax. I've been using this
library for 3 years and it still trips me up by accident sometimes >_<

This shouldn't break any existing behaviour, as far as I can tell.

Fixes #7