### PR TITLE
Export Error.Path

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -46,6 +46,11 @@ func (s Error) Code() uint8 {
 	return s.code
 }
 
+// Path for this error.
+func (s Error) Path() string {
+	return s.path
+}
+
 // Cause implements the causer interface from github.com/pkg/errors.
 func (s *Error) Cause() error {
 	return s.err


### PR DESCRIPTION
I'd like to do:

    err := formam.Decode(...)
    if err != nil {
        ferr, ok := err.(*formam.Error)
        if ok && ferr.Code() != formam.ErrCodeConversion {
		// Shown next to the form field.
		showError(ferr.Path(), "not a number")
        }
    }