### PR TITLE
Call UnmarshalText for every value if the name ends with []

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,10 @@ Supported types in the destination struct are:
 Custom Marshaling
 -----------------
 
-You can umarshal data and map keys by implementing the `encoding.TextUnmarshaler` interface.
+You can umarshal data and map keys by implementing the `encoding.TextUnmarshaler` interface. 
+
+If the forms sends multiple values then only the first value is passed to `UnmarshalText()`, but if the name ends with `[]` then it's called for all values.
+
 
 Custom Type
 -----------

--- a/formam.go
+++ b/formam.go
@@ -176,6 +176,7 @@ func (dec Decoder) init() error {
 			return err
 		}
 	}
+
 	// set values of maps
 	for _, v := range dec.maps {
 		key := v.field.Type().Key()
@@ -683,7 +684,18 @@ func (dec *Decoder) isUnmarshalText(v reflect.Value) (bool, error) {
 	if n.ConvertibleTo(typeTime) || n.ConvertibleTo(typeTimePtr) {
 		return false, nil
 	}
-	// return result
+
+	// Run on all values if the path ends with [].
+	if strings.HasSuffix(dec.path, "[]") {
+		for _, v := range dec.currValues {
+			err := m.UnmarshalText([]byte(v))
+			if err != nil {
+				return true, err
+			}
+		}
+		return true, nil
+	}
+
 	return true, m.UnmarshalText([]byte(dec.currValues[0]))
 }
 


### PR DESCRIPTION
I have the following problem: one of my forms has a setting with a
bitmask, this all works grand, but right now there is, as far as I can
find, no way to tell Formam to decode that since it always uses the
first value.

So with my form:

	<input type="checkbox" name="settings.collect[]" value="1"> One</label>
	<input type="checkbox" name="settings.collect[]" value="2"> Two</label>
	<input type="checkbox" name="settings.collect[]" value="4"> Two</label>

Formam will just set the first value that is selected.

With this change, if the name ends with "[]" it will call
UnmarshalText() on all values. I think it might make sense to just
always do this, but that wouldn't be backwards-compatible so this is
probably better.