### PR TITLE
Allow configuring time format

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/monoculum/formam"
+	"github.com/monoculum/formam/v3"
 )
 
 type Simple struct {


### PR DESCRIPTION
Right now formam decodes all time.Time values with 2006-01-02, without a way to specify a time or different format.

This adds the TimeFormats setting to control which time format(s) to try.